### PR TITLE
Slider support (#1)

### DIFF
--- a/src/main/java/fr/jmmc/oimaging/gui/ViewerPanel.java
+++ b/src/main/java/fr/jmmc/oimaging/gui/ViewerPanel.java
@@ -11,6 +11,7 @@ import fr.jmmc.jmcs.gui.util.SwingUtils;
 import fr.jmmc.jmcs.util.FileUtils;
 import fr.jmmc.jmcs.util.StringUtils;
 import fr.jmmc.oiexplorer.core.gui.FitsImagePanel;
+import fr.jmmc.oiexplorer.core.gui.SliderPanel;
 import fr.jmmc.oiexplorer.core.gui.model.KeywordsTableModel;
 import fr.jmmc.oimaging.Preferences;
 import fr.jmmc.oimaging.gui.action.ExportFitsImageAction;
@@ -55,6 +56,9 @@ public class ViewerPanel extends javax.swing.JPanel implements ChangeListener {
 
     /** OIFits viewer panel */
     private final OIFitsViewPanel oifitsViewPanel;
+    
+    /** Slider panel */
+    private SliderPanel sliderPanel;
 
     private final Action exportOiFitsAction;
     private final Action sendOiFitsAction;
@@ -84,6 +88,9 @@ public class ViewerPanel extends javax.swing.JPanel implements ChangeListener {
 
         fitsImagePanel = new FitsImagePanel(Preferences.getInstance(), true, true, null);
         jPanelImage.add(fitsImagePanel);
+        
+        sliderPanel = new SliderPanel(fitsImagePanel);
+        fitsImagePanel.addOptionPanel(sliderPanel);
 
         oifitsViewPanel = new OIFitsViewPanel();
         java.awt.GridBagConstraints gridBagConstraints = new java.awt.GridBagConstraints();
@@ -134,6 +141,11 @@ public class ViewerPanel extends javax.swing.JPanel implements ChangeListener {
 
     private void displaySelection(final FitsImageHDU imageHDU) {
         if (imageHDU != null) {
+            sliderPanel.setVisible(false);
+            if (imageHDU.getImageCount() > 1) {
+                sliderPanel.setFitsImages(imageHDU.getFitsImages());
+                sliderPanel.setVisible(true);
+            }
             FitsImage image = imageHDU.getFitsImages().get(0);
             fitsImagePanel.setFitsImage(image);
             jPanelImage.add(fitsImagePanel);


### PR DESCRIPTION
* Added support for fitsimage cubes display

* Changes in the way OImaging displays a fits file to allow display of image cubes

* The instance of SliderPanel is now generated by oimaging to avoid conflict with ASPRO2

* Fix visibility of FitsImagePanel.jPanelOptions

Co-authored-by: Martin Pratoussy <martin.pratoussy@cpe.fr>